### PR TITLE
Fix registerDID function

### DIFF
--- a/src/did-uri-validation.ts
+++ b/src/did-uri-validation.ts
@@ -55,10 +55,29 @@ export class DidUriValidation {
 
             if (
                   url &&
-                  url === `${networkConfiguration[0].testnet?.URL}` &&
+                  !contractAddress &&
                   did &&
                   didWithTestnet === "testnet"
             ) {
+                  contractAddress = `${networkConfiguration[0].testnet?.CONTRACT_ADDRESS}`;
+
+                  return {
+                        url,
+                        contractAddress,
+                  };
+            } else if (url && !contractAddress && did && didWithTestnet !== "testnet") {
+                  contractAddress = `${networkConfiguration[0].mainnet?.CONTRACT_ADDRESS}`;
+
+                  return {
+                        url,
+                        contractAddress,
+                  };
+            } else if (url && contractAddress && did) {
+                  return {
+                        url,
+                        contractAddress,
+                  };
+            } else if (!url && !contractAddress && did && didWithTestnet === "testnet") {
                   url = `${networkConfiguration[0].testnet?.URL}`;
                   contractAddress = `${networkConfiguration[0].testnet?.CONTRACT_ADDRESS}`;
 
@@ -66,15 +85,7 @@ export class DidUriValidation {
                         url,
                         contractAddress,
                   };
-            } else if (!url && did && didWithTestnet === "testnet") {
-                  url = `${networkConfiguration[0].testnet?.URL}`;
-                  contractAddress = `${networkConfiguration[0].testnet?.CONTRACT_ADDRESS}`;
-
-                  return {
-                        url,
-                        contractAddress,
-                  };
-            } else if (!url && did && didWithTestnet !== "testnet") {
+            } else if (!url && !contractAddress && did && didWithTestnet !== "testnet") {
                   url = `${networkConfiguration[1].mainnet?.URL}`;
                   contractAddress = `${networkConfiguration[1].mainnet?.CONTRACT_ADDRESS}`;
 


### PR DESCRIPTION
``await registerDID(did, privateKey, url?, contractAddress?);``
I need to use this function with a different url to register a DID but url and contractAddress wasn't taken into account.
In the file uri-did-validation.ts the default value (of url and contractAddress) was always use.
So I fix it to use a different url and contract address to register a DID.